### PR TITLE
Make getProperties method public in BaseEntity

### DIFF
--- a/google-cloud-clients/google-cloud-datastore/src/main/java/com/google/cloud/datastore/BaseEntity.java
+++ b/google-cloud-clients/google-cloud-datastore/src/main/java/com/google/cloud/datastore/BaseEntity.java
@@ -630,8 +630,9 @@ public abstract class BaseEntity<K extends IncompleteKey> implements Serializabl
   public Set<String> getNames() {
     return properties.keySet();
   }
-
-  ImmutableSortedMap<String, Value<?>> getProperties() {
+  
+  /** Returns the properties. */
+  public ImmutableSortedMap<String, Value<?>> getProperties() {
     return properties;
   }
 


### PR DESCRIPTION
This is a single commit to expose `getProperties` in Google Cloud's BaseEntity.
Branched off of releast `v0.81.0` https://github.com/googleapis/google-cloud-java/tree/v0.81.0
Which is version `1.63.0` which matches our Google Cloud 3rd party dependencies